### PR TITLE
Update release workflow to set gradle.properties version on manual dispatch

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -28,6 +28,16 @@ jobs:
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 
+      - name: Update gradle.properties with release version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAG_NAME="${{ inputs.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          echo "Updating gradle.properties version to ${VERSION}"
+          sed -i "s/^version=.*/version=${VERSION}/" gradle.properties
+          echo "Updated gradle.properties:"
+          grep '^version=' gradle.properties
+
       - name: Validate tag matches gradle.properties version
         run: |
           TAG_NAME="${{ inputs.tag_name || github.ref_name }}"
@@ -99,6 +109,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Update gradle.properties with release version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          TAG_NAME="${{ inputs.tag_name }}"
+          VERSION="${TAG_NAME#v}"
+          echo "Updating gradle.properties version to ${VERSION}"
+          sed -i.bak "s/^version=.*/version=${VERSION}/" gradle.properties
+          rm -f gradle.properties.bak
+          echo "Updated gradle.properties:"
+          grep '^version=' gradle.properties
 
       - name: Update PCGenProp.properties with release version and date
         run: |


### PR DESCRIPTION
When the release workflow is triggered manually via `workflow_dispatch`, the `gradle.properties` version is now updated to match the entered tag name (with the `v` prefix stripped).

This runs in both jobs:
- **create_release**: before the tag/version validation step, so it passes cleanly
- **build_release**: after checkout and before the build, so Gradle and the PCGenProp.properties update both pick up the correct version

Only activates on manual dispatch — tag-push releases are unaffected.